### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ionic-angular": "3.9.5",
     "ionic-plugin-keyboard": "^2.2.1",
     "ionicons": "3.0.0",
-    "npm": "^6.9.0",
     "rxjs": "5.5.11",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.29"


### PR DESCRIPTION

Hello Nditah!

It seems like you have npm as one of your (dev-) dependency in pmt-mobile-app.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
